### PR TITLE
Specify a secure directory when creating a new temporary file

### DIFF
--- a/robocode.battle/src/main/java/net/sf/robocode/recording/RecordManager.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/recording/RecordManager.java
@@ -121,7 +121,8 @@ public class RecordManager implements IRecordManager {
     private void createTempFile() {
         try {
             if (tempFile == null) {
-                tempFile = File.createTempFile("robocode-battle-records", ".tmp");
+                tempFile = File.createTempFile("robocode-battle-records", ".tmp",
+                        new File("/mySecureDirectory"));
                 tempFile.deleteOnExit();
             } else {
                 deleteTempFile();


### PR DESCRIPTION
Specify a secure directory when creating a new temporary file to fix the vulnerability #51 